### PR TITLE
Ship Ask backend compatibility

### DIFF
--- a/src/app/api/v2/my-posts/route.ts
+++ b/src/app/api/v2/my-posts/route.ts
@@ -54,7 +54,8 @@ export async function GET(request: NextRequest) {
   const { count: totalCount, error: countError } = await supabase
     .from("posts_v2")
     .select("*", { count: "exact", head: true })
-    .eq("user_id", user.id);
+    .eq("user_id", user.id)
+    .eq("content_type", "leak");
 
   if (countError) {
     console.error('Error getting post count:', countError);
@@ -66,6 +67,7 @@ export async function GET(request: NextRequest) {
     .from("posts_v2")
     .select("*, user_id(*)")
     .eq("user_id", user.id)
+    .eq("content_type", "leak")
     .order("created_at", { ascending: false })
     .range(offset, offset + limit - 1)
     .returns<Tables<"posts_v2">[]>();
@@ -85,6 +87,10 @@ export async function GET(request: NextRequest) {
     row: post.row,
     country_code: post.country_code,
     country_id: post.country_id,
+    coarse_location_kind: post.coarse_location_kind,
+    coarse_location_name: post.coarse_location_name,
+    coarse_location_resolved_at: post.coarse_location_resolved_at,
+    coarse_location_source: post.coarse_location_source,
     poi_id: post.poi_id,
     posted_from_poi: post.posted_from_poi,
     user_id: post.user_id,

--- a/src/app/api/v2/posts/create/route.ts
+++ b/src/app/api/v2/posts/create/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/utils/supabase/server";
+import { reverseGeocodeCoarseLocation } from "@/lib/postLocation";
 import { NextRequest, NextResponse } from "next/server";
 
 function validateContent(text: string): { isValid: boolean; error?: string } {
@@ -91,15 +92,63 @@ export async function POST(request: NextRequest) {
   const body = await request.json();
 
   // Validate content
+  if (typeof body.content !== "string") {
+    return NextResponse.json({ error: "Secret content is required" }, { status: 400 });
+  }
   const validation = validateContent(body.content);
   if (!validation.isValid) {
     return NextResponse.json({ error: validation.error }, { status: 400 });
   }
 
-  // Randomize coordinates within 200m radius
+  const exactLat = Number(userData.lat);
+  const exactLng = Number(userData.lng);
+  if (
+    !Number.isFinite(exactLat) ||
+    !Number.isFinite(exactLng) ||
+    exactLat < -90 ||
+    exactLat > 90 ||
+    exactLng < -180 ||
+    exactLng > 180
+  ) {
+    return NextResponse.json({ error: "A valid location is required" }, { status: 400 });
+  }
+
+  let coarseLocation = null;
+  const mapboxToken = process.env.MAPBOX_POST_LOCATION_TOKEN;
+  if (mapboxToken) {
+    const configuredCap = Number(
+      process.env.MAPBOX_POST_LOCATION_MONTHLY_CAP ?? "13000",
+    );
+    const monthlyCap = Math.max(
+      1,
+      Math.min(Number.isFinite(configuredCap) ? configuredCap : 13000, 100000),
+    );
+    const { data: reserved, error: reserveError } = await supabase.rpc(
+      "reserve_post_location_geocode",
+      { input_monthly_limit: monthlyCap },
+    );
+    if (reserveError) {
+      console.warn("Post location budget reservation failed", reserveError.message);
+    } else if (reserved) {
+      try {
+        coarseLocation = await reverseGeocodeCoarseLocation({
+          lat: exactLat,
+          lng: exactLng,
+          accessToken: mapboxToken,
+        });
+      } catch (error) {
+        console.warn(
+          "Post location lookup failed",
+          error instanceof Error ? error.message : "Unknown error",
+        );
+      }
+    }
+  }
+
+  // Randomize coordinates within 200m only after the exact-point lookup.
   const randomizedCoords = randomizeCoordinates(
-    userData.lat || 0,
-    userData.lng || 0,
+    exactLat,
+    exactLng,
     200
   );
 
@@ -108,7 +157,16 @@ export async function POST(request: NextRequest) {
     lat: randomizedCoords.lat,
     lng: randomizedCoords.lng,
     user_id: user.id,
-    poi_id: body.poi_id,
+    poi_id: body.poi_id ?? null,
+    posted_from_poi: Boolean(body.poi_id),
+    coarse_location_name: coarseLocation?.name ?? null,
+    coarse_location_kind: coarseLocation?.kind ?? null,
+    coarse_location_source: coarseLocation
+      ? "mapbox_exact_pre_fuzz"
+      : null,
+    coarse_location_resolved_at: coarseLocation
+      ? new Date().toISOString()
+      : null,
   });
 
   if (error) {

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -2,12 +2,15 @@ export default function PrivacyPolicy() {
   return (
     <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
       <h1 className="text-3xl font-bold mb-6">Privacy Policy</h1>
+      <p className="text-sm opacity-70">Last updated: August 9, 2026</p>
 
       <section className="space-y-4">
         <h2 className="text-2xl font-semibold">Overview</h2>
         <p>
-          Leaks (&quot;we&quot;, &quot;our&quot;, &quot;us&quot;) is an anonymous secret-sharing community. This policy explains what
-          data we collect, how we use it, and the choices you have. By using Leaks you agree to the
+          Leaks (&quot;we&quot;, &quot;our&quot;, &quot;us&quot;) is an anonymous
+          local community for sharing Leaks, asking questions, and answering
+          people nearby. This policy explains what data we collect, how we use
+          it, and the choices you have. By using Leaks you agree to the
           practices described below.
         </p>
       </section>
@@ -22,21 +25,46 @@ export default function PrivacyPolicy() {
             you and is not visible to other users.
           </li>
           <li>
-            <strong>Approximate Location&nbsp;Data:</strong> We collect your coarse location (for example, the
-            centre of the city block you are on) when you create or browse secrets so that we can surface
-            nearby content. The location displayed with a secret is further obfuscated so that no one can
-            determine your exact or real-time whereabouts.
+            <strong>Location&nbsp;Data:</strong> We use location when you create or browse local content so
+            that we can surface relevant Leaks and questions. By default, the map shows a stable,
+            obfuscated point rather than the exact coordinates selected for a post or question. An
+            author can revisit their own selected location, while another authenticated user needs
+            Premium to reveal it. A reveal does not provide live location tracking or the
+            author&rsquo;s identity.
           </li>
           <li>
             <strong>Gender:</strong> You are asked to select a gender when signing up. This information is used
-            only to personalise your experience (for example, filters and statistics) and is never shared
-            publicly.
+            to personalise your experience (for example, filters and statistics). If you select male or
+            female, it may also appear as a hint to the author of a Leak or question you deliberately
+            open, answer, like, or dislike. Other selections are omitted from Viewer Hints.
           </li>
           <li>
-            <strong>Secret Content:</strong> The text of the secrets you post is stored on our servers so that
-            it can be displayed to other users.
+            <strong>Community Content:</strong> The text of the Leaks, questions, and answers you post is
+            stored on our servers so that it can be displayed to other users. For Ask, the selected place
+            label and an approximate map point are public; the exact target coordinates remain protected
+            until an eligible viewer chooses to reveal them.
           </li>
         </ul>
+      </section>
+
+      <section id="location" className="space-y-4 scroll-mt-8">
+        <h2 className="text-2xl font-semibold">Location and Viewer Hints</h2>
+        <p>
+          Leaks uses your approximate location to show local content and may create a Viewer Hint when you
+          deliberately open, answer, like, or dislike someone else&rsquo;s Leak or accepted Ask question.
+          When location is available for that interaction, Premium authors may see one stable obfuscated
+          area with a radius of at least 500 metres, never your exact coordinates, name, email, or account
+          ID. We may also show available device family and OS details, interaction time, whether you
+          returned, the surface you opened from, your replies or reactions on that content, and male or
+          female if selected in your profile. Other gender selections are omitted. Passive feed
+          impressions do not create Viewer Hints.
+        </p>
+        <p>
+          Viewer Hints and exact-location reveals are separate features. A Viewer Hint never grants an
+          author access to a viewer&rsquo;s exact location. If Viewer Hints is disabled, new hint capture and
+          Viewer Hint notifications stop, but this does not change how exact post or question locations
+          are revealed.
+        </p>
       </section>
 
       <section className="space-y-4">
@@ -77,8 +105,8 @@ export default function PrivacyPolicy() {
         <h2 className="text-2xl font-semibold">Data Protection</h2>
         <p>
           We employ industry-standard technical and organisational measures to safeguard the data we hold.
-          Approximate location data is stored separately from precise coordinates and is never shared with
-          other users or third parties.
+          Viewer Hints store only an obfuscated approximate area and never expose a viewer&rsquo;s exact
+          coordinates or account identifier.
         </p>
       </section>
 

--- a/src/lib/postLocation.ts
+++ b/src/lib/postLocation.ts
@@ -1,0 +1,142 @@
+export type CoarseLocationKind =
+  | "locality"
+  | "place"
+  | "district"
+  | "region"
+  | "country";
+
+export type CoarseLocation = {
+  name: string;
+  kind: CoarseLocationKind;
+};
+
+type ContextItem = {
+  name?: string;
+  region_code?: string;
+  country_code?: string;
+};
+
+type MapboxResponse = {
+  features?: Array<{
+    properties?: {
+      feature_type?: string;
+      name?: string;
+      name_preferred?: string;
+      context?: Partial<Record<CoarseLocationKind, ContextItem>>;
+    };
+  }>;
+};
+
+const LOCATION_KINDS: CoarseLocationKind[] = [
+  "locality",
+  "place",
+  "district",
+  "region",
+  "country",
+];
+
+function cleanName(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const cleaned = value
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120);
+  return cleaned || null;
+}
+
+export function parseMapboxCoarseLocation(
+  payload: MapboxResponse,
+): CoarseLocation | null {
+  const candidates = new Map<CoarseLocationKind, ContextItem>();
+
+  for (const feature of payload.features ?? []) {
+    const properties = feature.properties;
+    const featureType = properties?.feature_type as CoarseLocationKind | undefined;
+    if (featureType && LOCATION_KINDS.includes(featureType)) {
+      candidates.set(featureType, {
+        name: properties?.name_preferred ?? properties?.name,
+        region_code: properties?.context?.region?.region_code,
+        country_code: properties?.context?.country?.country_code,
+      });
+    }
+    for (const kind of LOCATION_KINDS) {
+      const context = properties?.context?.[kind];
+      if (context?.name && !candidates.has(kind)) candidates.set(kind, context);
+    }
+  }
+
+  const countryCode = (
+    candidates.get("country")?.country_code ??
+    [...candidates.values()].find((item) => item.country_code)?.country_code ??
+    ""
+  ).toUpperCase();
+  const regionCode = (
+    candidates.get("region")?.region_code ??
+    [...candidates.values()].find((item) => item.region_code)?.region_code ??
+    ""
+  )
+    .split("-")
+    .at(-1)
+    ?.toUpperCase();
+
+  for (const kind of LOCATION_KINDS) {
+    const name = cleanName(candidates.get(kind)?.name);
+    if (!name) continue;
+    if (
+      (kind === "place" || kind === "district") &&
+      countryCode === "US" &&
+      regionCode
+    ) {
+      const suffix = `, ${regionCode}`;
+      return {
+        name: name.toUpperCase().endsWith(suffix) ? name : `${name}${suffix}`
+          .slice(0, 120),
+        kind,
+      };
+    }
+    return { name, kind };
+  }
+  return null;
+}
+
+export async function reverseGeocodeCoarseLocation({
+  lat,
+  lng,
+  accessToken,
+  timeoutMs = 1500,
+}: {
+  lat: number;
+  lng: number;
+  accessToken: string;
+  timeoutMs?: number;
+}): Promise<CoarseLocation | null> {
+  const params = new URLSearchParams({
+    longitude: String(lng),
+    latitude: String(lat),
+    types: LOCATION_KINDS.join(","),
+    language: "en",
+    permanent: "false",
+    access_token: accessToken,
+  });
+  if (params.get("permanent") !== "false") {
+    throw new Error("Permanent geocoding is disabled");
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(
+      `https://api.mapbox.com/search/geocode/v6/reverse?${params.toString()}`,
+      { signal: controller.signal },
+    );
+    if (!response.ok) {
+      throw new Error(`Mapbox reverse geocoding failed (${response.status})`);
+    }
+    return parseMapboxCoarseLocation(
+      (await response.json()) as MapboxResponse,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/types_db.ts
+++ b/types_db.ts
@@ -480,6 +480,10 @@ export type Database = {
       posts_v2: {
         Row: {
           col: number | null
+          coarse_location_kind: string | null
+          coarse_location_name: string | null
+          coarse_location_resolved_at: string | null
+          coarse_location_source: string | null
           content: string | null
           country_code: string | null
           country_id: string | null
@@ -505,6 +509,10 @@ export type Database = {
         }
         Insert: {
           col?: number | null
+          coarse_location_kind?: string | null
+          coarse_location_name?: string | null
+          coarse_location_resolved_at?: string | null
+          coarse_location_source?: string | null
           content?: string | null
           country_code?: string | null
           country_id?: string | null
@@ -530,6 +538,10 @@ export type Database = {
         }
         Update: {
           col?: number | null
+          coarse_location_kind?: string | null
+          coarse_location_name?: string | null
+          coarse_location_resolved_at?: string | null
+          coarse_location_source?: string | null
           content?: string | null
           country_code?: string | null
           country_id?: string | null
@@ -2541,6 +2553,14 @@ export type Database = {
           thread_id: number
           is_author: boolean
         }[]
+      }
+      reserve_post_location_geocode: {
+        Args: { input_monthly_limit?: number }
+        Returns: boolean
+      }
+      set_post_location_monthly_limit: {
+        Args: { input_monthly_limit: number }
+        Returns: Json
       }
       search_pois_by_name_and_distance: {
         Args: {


### PR DESCRIPTION
## Summary

- keep legacy My Posts responses Leak-only while returning coarse location metadata
- resolve coarse post labels before coordinate fuzzing when the server Mapbox token is configured
- document Ask, exact-location reveals, and Viewer Hints in the live privacy policy
- preserve the canonical Home-feed route already on main

## Compatibility

- production database migrations are already applied through 20260809133000
- older clients continue receiving Leak-only legacy payloads
- if the website Mapbox token is absent, posting still succeeds and the existing queued worker resolves the label from the fuzzed coordinate

## Verification

- npm run build
- Vercel preview Ready
- privacy page returned 200 HTML through preview protection bypass
- Home-feed and My Posts returned expected unauthenticated 401 JSON
- Posts Create returned expected unauthenticated 401 JSON with no write
